### PR TITLE
Adding val alias for getValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/data_wrapper.js
+++ b/src/data_wrapper.js
@@ -22,6 +22,9 @@ module.exports = function(_mixins, _cortexPubSub) {
     return this.__value;
   };
 
+  // Short alias for getValue
+  DataWrapper.prototype.val = DataWrapper.prototype.getValue;
+
   DataWrapper.prototype.getPath = function() {
     return this.__path;
   };


### PR DESCRIPTION
Not sure if you'd like to consider this, but while I like the consistency of get___ I find my primary use case is always getValue and it can feel verbose.

It would be nice actually if we could allow patching of DataWrapper similar to React.  For example you can do a

```
var ReactMount  = require('react/lib/ReactMount');
ReactMount.allowFullPageRender = true;
```

Which lets you change React without having to fork or anything messy. Will experiment with this, I could see it being as simple as:

```
var DataWrapper = require('cortexjs/src/data_wrapper');
DataWrapper.prototype.val = DataWrapper.prototype.getValue;
```
