### PR TITLE
Define delete method name as string to make MSIE8 happy

### DIFF
--- a/src/wrappers/hash.js
+++ b/src/wrappers/hash.js
@@ -16,7 +16,7 @@ var HashWrapper = {
     return this.__value[key] != null;
   },
 
-  delete: function(key) {
+  'delete': function(key) {
     var removed = this.__value[key];
     delete this.__value[key];
     this.__forceUpdate();


### PR DESCRIPTION
`delete` is a reserved word according to:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Reserved_Words

While other browsers don't mind, Microsoft Internet Explorer 8 does not play nice with it. 
In my limited testing this makes Cortex usable in MSIE8.
