### PR TITLE
Allow multiple callbacks to be set.

### DIFF
--- a/src/cortex.js
+++ b/src/cortex.js
@@ -21,7 +21,7 @@ Cortex = (function(_super, _cortexPubSub) {
   function Cortex(value, callback) {
     this.__value = value;
     this.__path = [];
-    this.__callback = callback;
+    this.__callbacks = callback ? [callback] : [];
     this.__subscribe();
     this.__wrap();
   }
@@ -30,7 +30,7 @@ Cortex = (function(_super, _cortexPubSub) {
 
   Cortex.prototype.on = function(event, callback) {
     if(event === "update") {
-      this.__callback = callback;
+      this.__callbacks.push(callback);
     }
   };
 
@@ -42,9 +42,13 @@ Cortex = (function(_super, _cortexPubSub) {
     this.__setValue(newValue, path);
     this.__rewrap(path);
 
-    if(this.__callback) {
-      return this.__callback(this);
-    }
+    this.__callbacks.forEach(function (callback) {
+        if(callback) {
+            callback(this);
+        }
+    });
+    return true;
+
   };
 
   Cortex.prototype.__subscribe = function() {

--- a/test/cortex_test.js
+++ b/test/cortex_test.js
@@ -31,7 +31,7 @@ describe("Cortex", function() {
 
         cortex.update({}, []);
 
-        expect(called1).toBe(false);
+        expect(called1).toBe(true);
         expect(called2).toBe(true);
       });
     });


### PR DESCRIPTION
I noticed that in the Readme you made an intentional decision to have each callback override the previous one. It seems more flexible to allow multiple callbacks.

I have a situation where on each update the DOM is updated via react, and the data is also synced with the server and its much cleaner this way.
