### PR TITLE
Fix callback enqueue for batch execution

### DIFF
--- a/src/cortex.js
+++ b/src/cortex.js
@@ -74,12 +74,13 @@ Cortex = (function(_super, _cortexPubSub) {
   };
 
   Cortex.prototype.__runCallbacks = function() {
+    this.__callbacksQueued = false;
+
     for(var i=0, ii=this.__callbacks.length;i < ii;i++) {
       if(this.__callbacks[i]) {
         this.__callbacks[i](this);
       }
     }
-    this.__callbacksQueued = false;
   };
 
   Cortex.prototype.__subscribe = function() {

--- a/test/cortex_test.js
+++ b/test/cortex_test.js
@@ -168,6 +168,21 @@ describe("Cortex", function() {
       expect(cortex.getValue()).toEqual([10, 20, 30, 40, 50]);
     });
 
+    it("update inside a callback call should be queued", function() {
+      var called = 0,
+          cortex = new Cortex(this.value, function(updatedCortex) {
+            updatedCortex.set({calledFrom: "callback"});
+            called += 1;
+          });
+
+      cortex.set({calledFrom: "outside"});
+
+      jasmine.Clock.tick(1);
+
+      expect(called).toBe(2);
+      expect(cortex.getValue()).toEqual({calledFrom: "callback"});
+    });
+
     it("sets value to new data", function() {
       var cortex = new Cortex(this.value),
           newValue = { foo: "bar" };


### PR DESCRIPTION
If an instance was updated while a callback were executing, 
it wouldn't enqueue the new callback call, few updates could be missed.
