### PR TITLE
removeAt with negative index

### DIFF
--- a/src/wrappers/array.js
+++ b/src/wrappers/array.js
@@ -60,6 +60,9 @@ var ArrayWrapper = {
   },
 
   removeAt: function(index, howMany) {
+    if(!isNaN(index) && index < 0) {
+      return void 0;
+    }
     if(isNaN(howMany) || howMany <= 0) {
       howMany = 1;
     }

--- a/test/wrappers/array_test.js
+++ b/test/wrappers/array_test.js
@@ -180,5 +180,13 @@ describe("ArrayWrapper", function() {
 
       expect(this.wrapper.removeAt.bind(0)).toThrow();
     });
+
+    it("doesn't remove anything when negative index", function() {
+      var originalLength = this.wrapper.count(),
+          removed = this.wrapper.removeAt(-1);
+
+      expect(this.wrapper.count()).toBe(originalLength);
+      expect(removed).toBe(undefined);
+    });
   });
 });


### PR DESCRIPTION
This prevents a negative index (typically `-1`) passed to `removeAt()` to alter the array. Without, it removes the last element of the array (`pop()` can be used for this).

Useful in situations where a valid index couldn't be found and no action should be taken:

``` javascript
cortex.removeAt(cortex.findIndex(someComparator));
```
