### PR TITLE
Use cdnjs; upgrade React to 0.12

### DIFF
--- a/examples/file_system/index.html
+++ b/examples/file_system/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/react/0.8.0/react-with-addons.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react-with-addons.min.js"></script>
     <script src="../../build/cortex.js"></script>
     <style>
       div#filesystem {

--- a/examples/skyline/index.html
+++ b/examples/skyline/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <link rel="stylesheet" type="text/css" media="screen" href="skyline.css">
-    <script src="http://fb.me/react-0.8.0.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.12.0/react.min.js"></script>
     <script src="../../build/cortex.js"></script>
   </head>
   <body>


### PR DESCRIPTION
    * Fix issue with loading React over http://, making the examples non-functional when served over HTTPS
    * Upgrade React version in the examples to 0.12