### PR TITLE
fix checkUpdate fails when value has not changed

### DIFF
--- a/src/cortex.js
+++ b/src/cortex.js
@@ -131,25 +131,25 @@ module.exports = (function() {
     // Check whether newValue is different, if not then return false to bypass rewrap and running callbacks.
     // Note that we cannot compare stringified values of old and new data because order of keys cannot be guaranteed.
     __checkUpdate(oldValue, newValue, path) {
-      var diffs;
+      var diffs, batchUpdate = true;
 
       if(oldValue) {
-        diffs = this.__diff(oldValue, newValue);
+        batchUpdate = false;
+      }
+
+      oldValue || (oldValue = this.__subValue(path));
+      diffs = this.__diff(oldValue, newValue);
+
+      if(diffs) {
+        // Add to queue to update in batch later.
+        if (batchUpdate) {
+          this.__updates.push({newValue: newValue, path: path});
+        }
+
         this.__computeChanges(diffs, path);
         return true;
       } else {
-        var oldValue = this.__subValue(path);
-        diffs = this.__diff(oldValue, newValue);
-
-        if(diffs) {
-          // Add to queue to update in batch later.
-          this.__updates.push({newValue: newValue, path: path});
-
-          this.__computeChanges(diffs, path);
-          return true;
-        } else {
-          return false
-        }
+        return false;
       }
     }
 

--- a/test/wrappers/array_test.js
+++ b/test/wrappers/array_test.js
@@ -174,6 +174,10 @@ describe("ArrayWrapper", function() {
           expect(wrapperElement.getValue()).toBe(newArray[i]);
         });
       });
+
+      it("doesn't fail when value has not changed", function() {
+        expect(this.wrapper.insertAt.bind(this.wrapper, 0, [])).not.toThrow();
+      });
     });
   });
 
@@ -195,10 +199,14 @@ describe("ArrayWrapper", function() {
       });
     });
 
+    it("doesn't fail when value has not changed", function() {
+      expect(this.wrapper.removeAt.bind(this.wrapper, 0, 0)).not.toThrow();
+    });
+
     it("fails when called on a non array", function() {
       this.wrapper = new Cortex(1);
 
-      expect(this.wrapper.removeAt.bind(0)).toThrow();
+      expect(this.wrapper.removeAt.bind(this.wrapper, 0)).toThrow();
     });
   });
 });


### PR DESCRIPTION
__computeChanges fails silently when there is no `diffs`