### PR TITLE
add npm shortcut to local gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "main": "./build/cortex",
   "engines": {
     "node": "*"
+  },
+  "scripts": {
+    "test": "gulp test"
   }
 }


### PR DESCRIPTION
An npm test script to remove the necessity of a global gulp install or prefixing the local gulp with the `node_modules/.bin` path.